### PR TITLE
wordlist.sq3に壊れたデータが登録されて地名語が全く抽出されない問題の修整

### DIFF
--- a/include/Dictionary.h
+++ b/include/Dictionary.h
@@ -90,7 +90,7 @@ namespace geonlp
 
     // 収録固有名クラス
     inline void set_subject(const std::vector<std::string>& v) { this->_set_string_list("subject", v); }
-    inline std::vector<std::string> get_subject() const throw (picojson::PicojsonException) { this->_get_string_list("subject"); }
+    inline std::vector<std::string> get_subject() const throw (picojson::PicojsonException) { return this->_get_string_list("subject"); }
 
     /// 定義済み項目から取得可能な利便性の高い情報
 

--- a/include/picojsonExt.h
+++ b/include/picojsonExt.h
@@ -105,7 +105,7 @@ namespace picojson
     inline bool has_key(const std::string& key) { int c = this->_v.get<picojson::object>().count(key); return c > 0; }
 
     // 要素を削除
-    inline int erase(const std::string& key) { this->_v.get<picojson::object>().erase(key); }
+    inline int erase(const std::string& key) { return this->_v.get<picojson::object>().erase(key); }
 
     // オブジェクトのキー一覧を取得する
     std::vector<std::string> get_keys() const;

--- a/libgeonlp/DBAccessor.cpp
+++ b/libgeonlp/DBAccessor.cpp
@@ -527,10 +527,10 @@ namespace geonlp
 	const Geoword* wp = &(geowords[i]);
 	std::string json = wp->toJson(); 
 	// パラメータのバインド
-	sqlite3_bind_text(stm, 1, wp->get_geonlp_id().c_str(), wp->get_geonlp_id().length(), SQLITE_STATIC);
+	sqlite3_bind_text(stm, 1, wp->get_geonlp_id().c_str(), wp->get_geonlp_id().length(), SQLITE_TRANSIENT);
 	sqlite3_bind_int(stm, 2, wp->get_dictionary_id());
-	sqlite3_bind_text(stm, 3, wp->get_entry_id().c_str(), wp->get_entry_id().length(), SQLITE_STATIC);
-	sqlite3_bind_text(stm, 4, json.c_str(), json.length(), SQLITE_STATIC);
+	sqlite3_bind_text(stm, 3, wp->get_entry_id().c_str(), wp->get_entry_id().length(), SQLITE_TRANSIENT);
+	sqlite3_bind_text(stm, 4, json.c_str(), json.length(), SQLITE_TRANSIENT);
 
 	// 実行
 	rc = sqlite3_step(stm);
@@ -620,9 +620,9 @@ namespace geonlp
 	const std::string& json = wp->toJson(); 
 	// パラメータのバインド
 	sqlite3_bind_int(stmt, 1, wp->get_internal_id());
-	sqlite3_bind_text(stmt, 2, user_code.c_str(), user_code.length(), SQLITE_STATIC);
-	sqlite3_bind_text(stmt, 3, dict_code.c_str(), dict_code.length(), SQLITE_STATIC);
-	sqlite3_bind_text(stmt, 4, json.c_str(), json.length(), SQLITE_STATIC);
+	sqlite3_bind_text(stmt, 2, user_code.c_str(), user_code.length(), SQLITE_TRANSIENT);
+	sqlite3_bind_text(stmt, 3, dict_code.c_str(), dict_code.length(), SQLITE_TRANSIENT);
+	sqlite3_bind_text(stmt, 4, json.c_str(), json.length(), SQLITE_TRANSIENT);
 
 	// 実行
 	rc = sqlite3_step(stmt);
@@ -718,9 +718,9 @@ namespace geonlp
 	const Wordlist* wp = &(wordlists[i]);
 	// パラメータのバインド
 	sqlite3_bind_int(stm, 1, wp->get_id());
-	sqlite3_bind_text(stm, 2, wp->get_surface().c_str(), wp->get_surface().length(), SQLITE_STATIC);
-	sqlite3_bind_text(stm, 3, wp->get_idlist().c_str(), wp->get_idlist().length(), SQLITE_STATIC);
-	sqlite3_bind_text(stm, 4, wp->get_yomi().c_str(), wp->get_yomi().length(), SQLITE_STATIC);
+	sqlite3_bind_text(stm, 2, wp->get_surface().c_str(), wp->get_surface().length(), SQLITE_TRANSIENT);
+	sqlite3_bind_text(stm, 3, wp->get_idlist().c_str(), wp->get_idlist().length(), SQLITE_TRANSIENT);
+	sqlite3_bind_text(stm, 4, wp->get_yomi().c_str(), wp->get_yomi().length(), SQLITE_TRANSIENT);
 
 	// 実行
 	rc = sqlite3_step(stm);
@@ -1020,10 +1020,10 @@ namespace geonlp
       unsigned int id = 0;
       for (std::vector<Wordlist>::iterator it = wordlists.begin(); it != wordlists.end(); it++) {
 	sqlite3_bind_int(stmt, 1, (*it).get_id());
-	sqlite3_bind_text(stmt, 2, (*it).get_key().c_str(), (*it).get_key().length(), SQLITE_STATIC);
-	sqlite3_bind_text(stmt, 3, (*it).get_surface().c_str(), (*it).get_surface().length(), SQLITE_STATIC);
-	sqlite3_bind_text(stmt, 4, (*it).get_idlist().c_str(), (*it).get_idlist().length(), SQLITE_STATIC);
-	sqlite3_bind_text(stmt, 5, (*it).get_yomi().c_str(), (*it).get_yomi().length(), SQLITE_STATIC);
+	sqlite3_bind_text(stmt, 2, (*it).get_key().c_str(), (*it).get_key().length(), SQLITE_TRANSIENT);
+	sqlite3_bind_text(stmt, 3, (*it).get_surface().c_str(), (*it).get_surface().length(), SQLITE_TRANSIENT);
+	sqlite3_bind_text(stmt, 4, (*it).get_idlist().c_str(), (*it).get_idlist().length(), SQLITE_TRANSIENT);
+	sqlite3_bind_text(stmt, 5, (*it).get_yomi().c_str(), (*it).get_yomi().length(), SQLITE_TRANSIENT);
 	
 	rc = sqlite3_step(stmt);
 	if (rc != SQLITE_DONE) {


### PR DESCRIPTION
## 現象

`echo '沖縄県の南海上で台風が発生しました' | geonlp_ma`
で地名語が全く認識されない。

期待する結果:
https://geonlp.ex.nii.ac.jp/docs/developers/system_developers/software/advanced.html

実際の結果:
```
沖縄	名詞,固有名詞,地域,一般,*,*,沖縄,オキナワ,オキナワ
県	名詞,接尾,地域,*,*,*,県,ケン,ケン
の	助詞,連体化,*,*,*,*,の,ノ,ノ
南海	名詞,固有名詞,組織,*,*,*,南海,ナンカイ,ナンカイ
上	名詞,固有名詞,地域,一般,*,*,上,ウエ,ウエ
で	助詞,格助詞,一般,*,*,*,で,デ,デ
台風	名詞,一般,*,*,*,*,台風,タイフウ,タイフー
が	助詞,格助詞,一般,*,*,*,が,ガ,ガ
発生	名詞,サ変接続,*,*,*,*,発生,ハッセイ,ハッセイ
し	動詞,自立,*,*,サ変・スル,連用形,する,シ,シ
まし	助動詞,*,*,*,特殊・マス,連用形,ます,マシ,マシ
た	助動詞,*,*,*,特殊・タ,基本形,た,タ,タ
EOS
```

## 調査

### 辞書ファイルサイズ
修整前:
```
 975920 geo_name_fullname.drt
3661824 geodic.sq3
 110318 mecabusr.dic
1363968 wordlist.sq3
```

修整後:
```
 9019008 geo_name_fullname.drt
67686400 geodic.sq3
 2281382 mecabusr.dic
12525568 wordlist.sq3
```

### wordlist.sq3内容

修整前:
![ng](https://user-images.githubusercontent.com/761487/46567797-b4b5c200-c974-11e8-8283-5739135727a5.png)
```
select count(*) from wordlist;
19730
```

修整後:
```
0|26線川|26線川|FWefYC:26線川|
1|8線の沢川|8線の沢川|wWGf7V:8線の沢川|
2|JR三山木|JR三山木|r2XsgD:JR三山木駅|ジェイアールミヤマキ
3|JR三山木駅|JR三山木駅|r2XsgD:JR三山木駅|ジェイアールミヤマキエキ
4|JR五位堂|JR五位堂|B4JZEA:JR五位堂駅|ジェイアールゴイドウ
5|JR五位堂駅|JR五位堂駅|B4JZEA:JR五位堂駅|ジェイアールゴイドウエキ
6|JR俊徳道|JR俊徳道|qIJKpF:JR俊徳道駅|ジェイアールシュントクドウ
7|JR俊徳道駅|JR俊徳道駅|qIJKpF:JR俊徳道駅|ジェイアールシュントクドウエキ
8|JR小倉|JR小倉|xKuv19:JR小倉駅|ジェイアールオグラ
9|JR小倉駅|JR小倉駅|xKuv19:JR小倉駅|ジェイアールオグラエキ
```
```
select count(*) from wordlist;
178588
```

## 原因

wordlist.sq3に登録されたデータが壊れている。

## 修整

sqlite3_bind_text()のSQLITE_STATIC引数を、SQLITE_TRANSIENTに置換。

## 環境

```
openSUSE Tumbleweed 20180924-0
Linux wasabi 4.18.8-1-default #1 SMP PREEMPT Sat Sep 15 14:10:30 UTC 2018 (f486469) x86_64 x86_64 x86_64 GNU/Linux

g++ (SUSE Linux) 8.2.1 20180831 [gcc-8-branch revision 264010]
sqlite3-devel 3.24.0-3.1
libboost_filesystem1_68_0-devel
libboost_regex1_68_0-devel
libboost_system1_68_0-devel
libboost_thread1_68_0-devel

mecab of 0.996
```
